### PR TITLE
Rename slash command and update documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DISCORD_TOKEN=your-bot-token
+DISCORD_APP_ID=your-app-id
+# DISCORD_GUILD_ID=optional-guild-id

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Build stage
+FROM golang:1.21-bullseye AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -o /bot ./cmd/bot
+
+# Runtime stage
+FROM debian:bullseye-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /bot /usr/local/bin/bot
+
+USER nobody
+
+ENTRYPOINT ["/usr/local/bin/bot"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Discord Message Saver Bot
+
+This project is a Discord bot built with Go and [discordgo](https://github.com/bwmarrin/discordgo). Users choose an emoji via a slash command and, when they react to a message with that emoji, the bot forwards the message to their DM with a Close button. Pressing Close removes the forwarded message.
+
+## Requirements
+
+- Go 1.20+
+- Discord Bot Token / Application ID
+- Docker (optional)
+
+## Environment variables
+
+| Name | Description |
+| --- | --- |
+| `DISCORD_TOKEN` | Bot token |
+| `DISCORD_APP_ID` | Application ID |
+| `DISCORD_GUILD_ID` | (Optional) Guild ID to register the command. Empty registers globally |
+
+Use `.env.example` as a reference when configuring the environment.
+
+## Running locally
+
+```bash
+go run ./cmd/bot
+```
+
+## Running with Docker
+
+```bash
+docker compose up --build
+```
+
+## Bot features
+
+1. `/set-bookmark-emoji` lets you select the emoji used to bookmark messages.
+2. Reacting with the registered emoji forwards the message (and attachment URLs) to your DM.
+3. The forwarded DM includes a Close button. Press it to delete the DM.
+
+The bot registers the slash command automatically when it starts, so no additional registration command is required.

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/example/discord-simple-reading-list/internal/bot"
+	"github.com/example/discord-simple-reading-list/internal/config"
+)
+
+func main() {
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("failed to load config: %v", err)
+	}
+
+	b, err := bot.New(cfg)
+	if err != nil {
+		log.Fatalf("failed to create bot: %v", err)
+	}
+
+	if err := b.Open(); err != nil {
+		log.Fatalf("failed to open bot connection: %v", err)
+	}
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
+	<-stop
+
+	if err := b.Close(); err != nil {
+		log.Fatalf("failed to close bot: %v", err)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.8"
+
+services:
+  bot:
+    build: .
+    env_file:
+      - .env
+    restart: unless-stopped

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/example/discord-simple-reading-list
+
+go 1.24.3
+
+require github.com/bwmarrin/discordgo v0.27.1
+
+require (
+	github.com/gorilla/websocket v1.4.2 // indirect
+	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b // indirect
+	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/bwmarrin/discordgo v0.27.1 h1:ib9AIc/dom1E/fSIulrBwnez0CToJE113ZGt4HoliGY=
+github.com/bwmarrin/discordgo v0.27.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b h1:7mWr3k41Qtv8XlltBkDkl8LoP3mpSgBW8BUoxtEdbXg=
+golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -1,0 +1,105 @@
+package bot
+
+import (
+	"log"
+
+	"github.com/bwmarrin/discordgo"
+
+	"github.com/example/discord-simple-reading-list/internal/commands"
+	"github.com/example/discord-simple-reading-list/internal/config"
+	"github.com/example/discord-simple-reading-list/internal/handlers"
+	"github.com/example/discord-simple-reading-list/internal/store"
+)
+
+// Bot encapsulates the Discord session and all registered handlers.
+type Bot struct {
+	session        *discordgo.Session
+	config         *config.Config
+	store          *store.EmojiStore
+	registerCmd    *commands.SetBookmarkEmojiCommand
+	reactionHandle *handlers.ReactionHandler
+	commandIDs     []string
+}
+
+// New constructs a new Bot instance.
+func New(cfg *config.Config) (*Bot, error) {
+	session, err := discordgo.New("Bot " + cfg.BotToken)
+	if err != nil {
+		return nil, err
+	}
+
+	emojiStore := store.NewEmojiStore()
+	registerCommand := commands.NewSetBookmarkEmojiCommand(emojiStore)
+	reactionHandler := handlers.NewReactionHandler(emojiStore)
+
+	b := &Bot{
+		session:        session,
+		config:         cfg,
+		store:          emojiStore,
+		registerCmd:    registerCommand,
+		reactionHandle: reactionHandler,
+	}
+
+	session.AddHandler(b.onInteraction)
+	session.AddHandler(reactionHandler.Handle)
+
+	session.Identify.Intents = discordgo.IntentsGuilds | discordgo.IntentsGuildMessages | discordgo.IntentsGuildMessageReactions | discordgo.IntentsDirectMessages
+
+	return b, nil
+}
+
+// Open registers slash commands and opens the Discord websocket connection.
+func (b *Bot) Open() error {
+	if err := b.registerCommands(); err != nil {
+		return err
+	}
+
+	if err := b.session.Open(); err != nil {
+		return err
+	}
+
+	log.Println("bot is running. Press CTRL-C to exit")
+	return nil
+}
+
+// Close cleans up resources and unregisters commands.
+func (b *Bot) Close() error {
+	if len(b.commandIDs) > 0 {
+		for _, id := range b.commandIDs {
+			if err := b.session.ApplicationCommandDelete(b.config.AppID, b.config.GuildID, id); err != nil {
+				log.Printf("failed to delete command %s: %v", id, err)
+			}
+		}
+	}
+
+	if err := b.session.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (b *Bot) registerCommands() error {
+	cmd := b.registerCmd.Definition()
+
+	created, err := b.session.ApplicationCommandCreate(b.config.AppID, b.config.GuildID, cmd)
+	if err != nil {
+		return err
+	}
+
+	b.commandIDs = append(b.commandIDs, created.ID)
+	return nil
+}
+
+func (b *Bot) onInteraction(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	switch i.Type {
+	case discordgo.InteractionApplicationCommand:
+		if i.ApplicationCommandData().Name == commands.SetBookmarkEmojiCommandName {
+			if err := b.registerCmd.Handle(s, i); err != nil {
+				log.Printf("failed to handle register command: %v", err)
+			}
+		}
+	case discordgo.InteractionMessageComponent:
+		handlers.ComponentHandler(s, i)
+	}
+}

--- a/internal/commands/register.go
+++ b/internal/commands/register.go
@@ -1,0 +1,101 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+
+	"github.com/example/discord-simple-reading-list/internal/store"
+)
+
+// SetBookmarkEmojiCommandName identifies the slash command for selecting the bookmark reaction emoji.
+const SetBookmarkEmojiCommandName = "set-bookmark-emoji"
+
+// SetBookmarkEmojiCommand handles the `/set-bookmark-emoji` slash command lifecycle.
+type SetBookmarkEmojiCommand struct {
+	store *store.EmojiStore
+}
+
+// NewSetBookmarkEmojiCommand constructs a new SetBookmarkEmojiCommand.
+func NewSetBookmarkEmojiCommand(store *store.EmojiStore) *SetBookmarkEmojiCommand {
+	return &SetBookmarkEmojiCommand{store: store}
+}
+
+// Definition returns the discordgo.ApplicationCommand definition for registration.
+func (c *SetBookmarkEmojiCommand) Definition() *discordgo.ApplicationCommand {
+	return &discordgo.ApplicationCommand{
+		Name:        SetBookmarkEmojiCommandName,
+		Description: "Choose the emoji used to save messages to your DM",
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Type:        discordgo.ApplicationCommandOptionString,
+				Name:        "emoji",
+				Description: "Emoji to watch for when you react to a message",
+				Required:    true,
+			},
+		},
+	}
+}
+
+// Handle executes the command when invoked by a user.
+func (c *SetBookmarkEmojiCommand) Handle(s *discordgo.Session, i *discordgo.InteractionCreate) error {
+	if i.Type != discordgo.InteractionApplicationCommand {
+		return nil
+	}
+
+	options := i.ApplicationCommandData().Options
+	if len(options) == 0 {
+		return fmt.Errorf("emoji option is required")
+	}
+
+	rawEmoji := strings.TrimSpace(options[0].StringValue())
+	if rawEmoji == "" {
+		return fmt.Errorf("emoji option is required")
+	}
+
+	normalized := normalizeEmoji(rawEmoji)
+
+	user := i.Member.User
+	if user == nil {
+		user = i.User
+	}
+	if user == nil {
+		return fmt.Errorf("unable to resolve user from interaction")
+	}
+
+	c.store.Set(user.ID, normalized)
+
+	response := fmt.Sprintf("Set %s as your bookmark emoji. React with it to save messages to your DM!", rawEmoji)
+	return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: response,
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
+	})
+}
+
+func normalizeEmoji(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+
+	if strings.HasPrefix(trimmed, "<") && strings.HasSuffix(trimmed, ">") {
+		inner := strings.Trim(trimmed[1:len(trimmed)-1], ":")
+		parts := strings.Split(inner, ":")
+
+		switch len(parts) {
+		case 2:
+			return strings.Join(parts, ":")
+		case 3:
+			if parts[0] == "a" {
+				return strings.Join(parts, ":")
+			}
+			return strings.Join(parts[1:], ":")
+		}
+	}
+
+	return trimmed
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+// Config holds runtime configuration values loaded from environment variables.
+type Config struct {
+	BotToken string
+	AppID    string
+	GuildID  string
+}
+
+// Load reads configuration from environment variables and validates that the required
+// values are provided.
+func Load() (*Config, error) {
+	token := os.Getenv("DISCORD_TOKEN")
+	if token == "" {
+		return nil, fmt.Errorf("DISCORD_TOKEN is required")
+	}
+
+	appID := os.Getenv("DISCORD_APP_ID")
+	if appID == "" {
+		return nil, fmt.Errorf("DISCORD_APP_ID is required")
+	}
+
+	guildID := os.Getenv("DISCORD_GUILD_ID")
+
+	return &Config{
+		BotToken: token,
+		AppID:    appID,
+		GuildID:  guildID,
+	}, nil
+}

--- a/internal/handlers/components.go
+++ b/internal/handlers/components.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"log"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// CloseButtonID identifies the component button that closes a forwarded message.
+const CloseButtonID = "close_dm"
+
+// ComponentHandler processes interactions originating from message components.
+func ComponentHandler(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	if i.Type != discordgo.InteractionMessageComponent {
+		return
+	}
+
+	switch i.MessageComponentData().CustomID {
+	case CloseButtonID:
+		if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{Type: discordgo.InteractionResponseDeferredMessageUpdate}); err != nil {
+			log.Printf("failed to acknowledge close button interaction: %v", err)
+			return
+		}
+
+		if err := s.ChannelMessageDelete(i.ChannelID, i.Message.ID); err != nil {
+			log.Printf("failed to delete forwarded message: %v", err)
+		}
+	}
+}

--- a/internal/handlers/reaction.go
+++ b/internal/handlers/reaction.go
@@ -1,0 +1,119 @@
+package handlers
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+
+	"github.com/example/discord-simple-reading-list/internal/store"
+)
+
+// ReactionHandler sends a direct message when a user reacts with their registered emoji.
+type ReactionHandler struct {
+	store *store.EmojiStore
+}
+
+// NewReactionHandler constructs a ReactionHandler.
+func NewReactionHandler(store *store.EmojiStore) *ReactionHandler {
+	return &ReactionHandler{store: store}
+}
+
+// Handle reacts to MessageReactionAdd events.
+func (h *ReactionHandler) Handle(s *discordgo.Session, event *discordgo.MessageReactionAdd) {
+	if event.UserID == "" {
+		return
+	}
+
+	if botUser := s.State.User; botUser != nil && event.UserID == botUser.ID {
+		return
+	}
+
+	emoji, ok := h.store.Get(event.UserID)
+	if !ok {
+		return
+	}
+
+	reactionID := event.Emoji.APIName()
+	if reactionID == "" {
+		reactionID = event.Emoji.Name
+	}
+
+	if reactionID != emoji {
+		return
+	}
+
+	msg, err := s.ChannelMessage(event.ChannelID, event.MessageID)
+	if err != nil {
+		log.Printf("failed to fetch message: %v", err)
+		return
+	}
+
+	channelName := fetchChannelName(s, event.ChannelID)
+
+	dmChannel, err := s.UserChannelCreate(event.UserID)
+	if err != nil {
+		log.Printf("failed to create DM channel: %v", err)
+		return
+	}
+
+	content := buildForwardedMessageContent(msg, channelName)
+	_, err = s.ChannelMessageSendComplex(dmChannel.ID, &discordgo.MessageSend{
+		Content: content,
+		Components: []discordgo.MessageComponent{
+			discordgo.ActionsRow{
+				Components: []discordgo.MessageComponent{
+					discordgo.Button{
+						Label:    "Close",
+						Style:    discordgo.DangerButton,
+						CustomID: CloseButtonID,
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		log.Printf("failed to send DM: %v", err)
+	}
+}
+
+func fetchChannelName(s *discordgo.Session, channelID string) string {
+	if channel, err := s.State.Channel(channelID); err == nil && channel != nil {
+		return channel.Name
+	}
+
+	channel, err := s.Channel(channelID)
+	if err != nil {
+		log.Printf("failed to fetch channel name: %v", err)
+		return channelID
+	}
+
+	if channel.Name != "" {
+		return channel.Name
+	}
+
+	return channelID
+}
+
+func buildForwardedMessageContent(msg *discordgo.Message, channelName string) string {
+	var builder strings.Builder
+	builder.WriteString("**Saved message**\n")
+	builder.WriteString(fmt.Sprintf("Author: %s\n", msg.Author.Username))
+	builder.WriteString(fmt.Sprintf("Channel: #%s\n\n", channelName))
+
+	if msg.Content != "" {
+		builder.WriteString(msg.Content)
+		builder.WriteString("\n")
+	}
+
+	if len(msg.Attachments) > 0 {
+		builder.WriteString("\nAttachments:\n")
+		for _, attachment := range msg.Attachments {
+			builder.WriteString(attachment.URL)
+			builder.WriteString("\n")
+		}
+	}
+
+	return strings.TrimSpace(builder.String())
+}

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -1,0 +1,31 @@
+package store
+
+import "sync"
+
+// EmojiStore provides thread-safe storage for user specific emoji preferences.
+type EmojiStore struct {
+	mu     sync.RWMutex
+	emojis map[string]string
+}
+
+// NewEmojiStore initializes an empty EmojiStore.
+func NewEmojiStore() *EmojiStore {
+	return &EmojiStore{
+		emojis: make(map[string]string),
+	}
+}
+
+// Set associates an emoji with a given user ID.
+func (s *EmojiStore) Set(userID, emoji string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.emojis[userID] = emoji
+}
+
+// Get retrieves the emoji associated with the user ID, if any.
+func (s *EmojiStore) Get(userID string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	emoji, ok := s.emojis[userID]
+	return emoji, ok
+}


### PR DESCRIPTION
## Summary
- rename the slash command to `/set-bookmark-emoji` for clearer purpose and update bot wiring
- adjust the command response copy to reference the bookmark emoji wording
- rewrite the README in English and note that slash commands register automatically on startup

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68db16ceb2408330b1f9cb2e58187872