### PR TITLE
Allow explicit black embed color and document command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,19 @@ docker compose up --build
 
 ## Bot features
 
-1. `/set-bookmark-emoji` lets you select the emoji used to bookmark messages.
-2. Reacting with the registered emoji forwards the message (and attachment URLs) to your DM.
+1. `/set-bookmark-emoji` lets you select one or more emojis (comma or space separated) used to bookmark messages and optionally choose a hex embed color.
+2. Reacting with any registered emoji forwards the message (and attachment URLs) to your DM inside an embed that honours your color preference.
 3. The forwarded DM includes a Close button. Press it to delete the DM.
 
 The bot registers the slash command automatically when it starts, so no additional registration command is required.
+
+### Command usage
+
+Use the following format when customising the bookmark behaviour:
+
+```
+/set-bookmark-emoji emoji:"📚 🔖" color:#ffcc00
+```
+
+- Provide one or more emojis separated by spaces or commas. Custom server emojis are supported as usual (e.g. `<:name:123456>`).
+- The optional `color` argument accepts a 6-digit hex value with or without `#`/`0x` prefixes. Leave it out to fall back to the bot default.

--- a/internal/commands/register.go
+++ b/internal/commands/register.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/bwmarrin/discordgo"
@@ -31,8 +32,14 @@ func (c *SetBookmarkEmojiCommand) Definition() *discordgo.ApplicationCommand {
 			{
 				Type:        discordgo.ApplicationCommandOptionString,
 				Name:        "emoji",
-				Description: "Emoji to watch for when you react to a message",
+				Description: "Emoji (or emojis separated by spaces or commas) to watch for when you react to a message",
 				Required:    true,
+			},
+			{
+				Type:        discordgo.ApplicationCommandOptionString,
+				Name:        "color",
+				Description: "Optional hex color (e.g. #ffcc00) for the saved message embed",
+				Required:    false,
 			},
 		},
 	}
@@ -49,12 +56,36 @@ func (c *SetBookmarkEmojiCommand) Handle(s *discordgo.Session, i *discordgo.Inte
 		return fmt.Errorf("emoji option is required")
 	}
 
-	rawEmoji := strings.TrimSpace(options[0].StringValue())
+	var rawEmoji string
+	var rawColor string
+
+	for _, option := range options {
+		switch option.Name {
+		case "emoji":
+			rawEmoji = strings.TrimSpace(option.StringValue())
+		case "color":
+			rawColor = strings.TrimSpace(option.StringValue())
+		}
+	}
+
 	if rawEmoji == "" {
 		return fmt.Errorf("emoji option is required")
 	}
 
-	normalized := normalizeEmoji(rawEmoji)
+	emojiTokens := splitEmojiInput(rawEmoji)
+	if len(emojiTokens) == 0 {
+		return fmt.Errorf("please provide at least one emoji")
+	}
+
+	normalized := normalizeEmojis(emojiTokens)
+	if len(normalized) == 0 {
+		return fmt.Errorf("unable to understand the provided emojis")
+	}
+
+	color, hasColor, err := parseColor(rawColor)
+	if err != nil {
+		return err
+	}
 
 	user := i.Member.User
 	if user == nil {
@@ -64,9 +95,13 @@ func (c *SetBookmarkEmojiCommand) Handle(s *discordgo.Session, i *discordgo.Inte
 		return fmt.Errorf("unable to resolve user from interaction")
 	}
 
-	c.store.Set(user.ID, normalized)
+	c.store.Set(user.ID, store.UserPreferences{Emojis: normalized, Color: color, HasColor: hasColor})
 
-	response := fmt.Sprintf("Set %s as your bookmark emoji. React with it to save messages to your DM!", rawEmoji)
+	displayEmoji := strings.Join(emojiTokens, ", ")
+	response := fmt.Sprintf("Saved %s as your bookmark emoji(s). React with them to save messages to your DM!", displayEmoji)
+	if hasColor {
+		response += fmt.Sprintf(" Embed color set to #%s.", strings.ToUpper(fmt.Sprintf("%06x", color)))
+	}
 	return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
@@ -98,4 +133,62 @@ func normalizeEmoji(value string) string {
 	}
 
 	return trimmed
+}
+
+func splitEmojiInput(raw string) []string {
+	replacer := strings.NewReplacer(",", " ", "\n", " ")
+	cleaned := replacer.Replace(raw)
+	fields := strings.Fields(cleaned)
+
+	var result []string
+	for _, field := range fields {
+		trimmed := strings.TrimSpace(field)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+
+	return result
+}
+
+func normalizeEmojis(values []string) []string {
+	seen := make(map[string]struct{})
+	var normalized []string
+
+	for _, value := range values {
+		emoji := normalizeEmoji(value)
+		if emoji == "" {
+			continue
+		}
+
+		if _, ok := seen[emoji]; ok {
+			continue
+		}
+
+		seen[emoji] = struct{}{}
+		normalized = append(normalized, emoji)
+	}
+
+	return normalized
+}
+
+func parseColor(value string) (int, bool, error) {
+	if value == "" {
+		return 0, false, nil
+	}
+
+	cleaned := strings.ToLower(strings.TrimSpace(value))
+	cleaned = strings.TrimPrefix(cleaned, "0x")
+	cleaned = strings.TrimPrefix(cleaned, "#")
+
+	if len(cleaned) != 6 {
+		return 0, false, fmt.Errorf("color must be a 6 digit hex code")
+	}
+
+	parsed, err := strconv.ParseInt(cleaned, 16, 32)
+	if err != nil {
+		return 0, false, fmt.Errorf("invalid color value: %w", err)
+	}
+
+	return int(parsed), true, nil
 }

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -2,30 +2,37 @@ package store
 
 import "sync"
 
+// UserPreferences stores the emoji and presentation configuration for a user.
+type UserPreferences struct {
+	Emojis   []string
+	Color    int
+	HasColor bool
+}
+
 // EmojiStore provides thread-safe storage for user specific emoji preferences.
 type EmojiStore struct {
-	mu     sync.RWMutex
-	emojis map[string]string
+	mu    sync.RWMutex
+	prefs map[string]UserPreferences
 }
 
 // NewEmojiStore initializes an empty EmojiStore.
 func NewEmojiStore() *EmojiStore {
 	return &EmojiStore{
-		emojis: make(map[string]string),
+		prefs: make(map[string]UserPreferences),
 	}
 }
 
-// Set associates an emoji with a given user ID.
-func (s *EmojiStore) Set(userID, emoji string) {
+// Set associates emoji preferences with a given user ID.
+func (s *EmojiStore) Set(userID string, prefs UserPreferences) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.emojis[userID] = emoji
+	s.prefs[userID] = prefs
 }
 
-// Get retrieves the emoji associated with the user ID, if any.
-func (s *EmojiStore) Get(userID string) (string, bool) {
+// Get retrieves the preferences associated with the user ID, if any.
+func (s *EmojiStore) Get(userID string) (UserPreferences, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	emoji, ok := s.emojis[userID]
-	return emoji, ok
+	prefs, ok := s.prefs[userID]
+	return prefs, ok
 }


### PR DESCRIPTION
## Summary
- preserve whether a user supplied a custom embed color when saving preferences
- only fall back to the default embed colour if no preference was set and honour #000000 selections
- extend the README with multi-emoji and colour usage guidance for the bookmark command

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68db5bac73348330bf7a6670853a4c6a