### PR TITLE
Add per-emoji bookmark modes and embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Discord Message Saver Bot
 
-This project is a Discord bot built with Go and [discordgo](https://github.com/bwmarrin/discordgo). Users choose an emoji via a slash command and, when they react to a message with that emoji, the bot forwards the message to their DM with a Close button. Pressing Close removes the forwarded message.
+This project is a Discord bot built with Go and [discordgo](https://github.com/bwmarrin/discordgo). Users can associate multiple emojis with different bookmark modes and, when they react to a message with one of those emojis, the bot forwards the message to their DM with the appropriate layout and controls.
 
 ## Requirements
 
@@ -32,9 +32,9 @@ docker compose up --build
 
 ## Bot features
 
-1. `/set-bookmark-emoji` lets you select one or more emojis (comma or space separated) used to bookmark messages and optionally choose a hex embed color.
-2. Reacting with any registered emoji forwards the message (and attachment URLs) to your DM inside an embed that honours your color preference.
-3. The forwarded DM includes a Close button. Press it to delete the DM.
+1. `/set-bookmark` lets you choose an emoji, assign it to one of three bookmark modes, and optionally pick an embed color.
+2. Reacting with any registered emoji forwards the message to your DM using the configured mode (lightweight, balanced, or complete).
+3. Saved messages include mode-specific action buttons such as ✅ 完了, 🗑️ 削除, and 🔗 元メッセージ.
 
 The bot registers the slash command automatically when it starts, so no additional registration command is required.
 
@@ -43,8 +43,11 @@ The bot registers the slash command automatically when it starts, so no addition
 Use the following format when customising the bookmark behaviour:
 
 ```
-/set-bookmark-emoji emoji:"📚 🔖" color:#ffcc00
+/set-bookmark emoji:👀 mode:lightweight color:#FFD700
+/set-bookmark emoji:🔖 mode:balanced
+/set-bookmark emoji:📌 mode:complete color:#FF6B6B
 ```
 
-- Provide one or more emojis separated by spaces or commas. Custom server emojis are supported as usual (e.g. `<:name:123456>`).
+- Provide exactly one emoji per command execution. Custom server emojis are supported as usual (e.g. `<:name:123456>`).
+- Choose between `lightweight`, `balanced`, or `complete` for the `mode` option.
 - The optional `color` argument accepts a 6-digit hex value with or without `#`/`0x` prefixes. Leave it out to fall back to the bot default.

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -16,7 +16,7 @@ type Bot struct {
 	session        *discordgo.Session
 	config         *config.Config
 	store          *store.EmojiStore
-	registerCmd    *commands.SetBookmarkEmojiCommand
+	registerCmd    *commands.SetBookmarkCommand
 	reactionHandle *handlers.ReactionHandler
 	commandIDs     []string
 }
@@ -29,7 +29,7 @@ func New(cfg *config.Config) (*Bot, error) {
 	}
 
 	emojiStore := store.NewEmojiStore()
-	registerCommand := commands.NewSetBookmarkEmojiCommand(emojiStore)
+	registerCommand := commands.NewSetBookmarkCommand(emojiStore)
 	reactionHandler := handlers.NewReactionHandler(emojiStore)
 
 	b := &Bot{
@@ -94,7 +94,7 @@ func (b *Bot) registerCommands() error {
 func (b *Bot) onInteraction(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	switch i.Type {
 	case discordgo.InteractionApplicationCommand:
-		if i.ApplicationCommandData().Name == commands.SetBookmarkEmojiCommandName {
+		if i.ApplicationCommandData().Name == commands.SetBookmarkCommandName {
 			if err := b.registerCmd.Handle(s, i); err != nil {
 				log.Printf("failed to handle register command: %v", err)
 			}

--- a/internal/handlers/components.go
+++ b/internal/handlers/components.go
@@ -6,8 +6,11 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-// CloseButtonID identifies the component button that closes a forwarded message.
-const CloseButtonID = "close_dm"
+// CompleteButtonID identifies the button that marks a lightweight bookmark as complete.
+const CompleteButtonID = "bookmark_complete"
+
+// DeleteButtonID identifies the button that deletes a saved bookmark message.
+const DeleteButtonID = "bookmark_delete"
 
 // ComponentHandler processes interactions originating from message components.
 func ComponentHandler(s *discordgo.Session, i *discordgo.InteractionCreate) {
@@ -15,15 +18,16 @@ func ComponentHandler(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		return
 	}
 
-	switch i.MessageComponentData().CustomID {
-	case CloseButtonID:
+	customID := i.MessageComponentData().CustomID
+	switch customID {
+	case CompleteButtonID, DeleteButtonID:
 		if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{Type: discordgo.InteractionResponseDeferredMessageUpdate}); err != nil {
-			log.Printf("failed to acknowledge close button interaction: %v", err)
+			log.Printf("failed to acknowledge bookmark component interaction: %v", err)
 			return
 		}
 
 		if err := s.ChannelMessageDelete(i.ChannelID, i.Message.ID); err != nil {
-			log.Printf("failed to delete forwarded message: %v", err)
+			log.Printf("failed to delete bookmarked message: %v", err)
 		}
 	}
 }

--- a/internal/handlers/reaction.go
+++ b/internal/handlers/reaction.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
 
@@ -42,7 +43,8 @@ func (h *ReactionHandler) Handle(s *discordgo.Session, event *discordgo.MessageR
 		reactionID = event.Emoji.Name
 	}
 
-	if !emojiMatches(prefs.Emojis, reactionID) {
+	pref, ok := prefs.Emojis[reactionID]
+	if !ok {
 		return
 	}
 
@@ -60,27 +62,30 @@ func (h *ReactionHandler) Handle(s *discordgo.Session, event *discordgo.MessageR
 		return
 	}
 
-	color := prefs.Color
-	if !prefs.HasColor {
+	color := pref.Color
+	if !pref.HasColor {
 		color = defaultEmbedColor
 	}
 
 	jumpURL := buildJumpLink(event.GuildID, event.ChannelID, event.MessageID)
-	embed := buildForwardedMessageEmbed(msg, channelName, jumpURL, color)
-	_, err = s.ChannelMessageSendComplex(dmChannel.ID, &discordgo.MessageSend{
-		Embeds: []*discordgo.MessageEmbed{embed},
-		Components: []discordgo.MessageComponent{
-			discordgo.ActionsRow{
-				Components: []discordgo.MessageComponent{
-					discordgo.Button{
-						Label:    "Close",
-						Style:    discordgo.DangerButton,
-						CustomID: CloseButtonID,
-					},
-				},
-			},
-		},
-	})
+	var messageSend *discordgo.MessageSend
+
+	switch pref.Mode {
+	case store.ModeLightweight:
+		messageSend = buildLightweightBookmark(msg, channelName, jumpURL, color, &event.Emoji)
+	case store.ModeComplete:
+		messageSend = buildCompleteBookmark(msg, channelName, jumpURL, color)
+	case store.ModeBalanced:
+		messageSend = buildBalancedBookmark(msg, channelName, jumpURL, color)
+	default:
+		messageSend = buildBalancedBookmark(msg, channelName, jumpURL, color)
+	}
+
+	if messageSend == nil {
+		return
+	}
+
+	_, err = s.ChannelMessageSendComplex(dmChannel.ID, messageSend)
 	if err != nil {
 		log.Printf("failed to send DM: %v", err)
 	}
@@ -104,19 +109,152 @@ func fetchChannelName(s *discordgo.Session, channelID string) string {
 	return channelID
 }
 
-func buildForwardedMessageEmbed(msg *discordgo.Message, channelName, jumpURL string, color int) *discordgo.MessageEmbed {
+func buildJumpLink(guildID, channelID, messageID string) string {
+	if guildID == "" {
+		return fmt.Sprintf("https://discord.com/channels/@me/%s/%s", channelID, messageID)
+	}
+
+	return fmt.Sprintf("https://discord.com/channels/%s/%s/%s", guildID, channelID, messageID)
+}
+
+func buildLightweightBookmark(msg *discordgo.Message, channelName, jumpURL string, color int, emoji *discordgo.Emoji) *discordgo.MessageSend {
+	titleEmoji := "👀"
+	if emoji != nil && emoji.Name != "" {
+		titleEmoji = emoji.Name
+	}
+
 	embed := &discordgo.MessageEmbed{
-		Title: "Saved message",
+		Title: fmt.Sprintf("%s 後で読む", titleEmoji),
 		Color: color,
 		Fields: []*discordgo.MessageEmbedField{
 			{
-				Name:   "Author",
+				Name:   "チャンネル",
+				Value:  fmt.Sprintf("#%s", channelName),
+				Inline: true,
+			},
+			{
+				Name:   "保存日時",
+				Value:  time.Now().Format("2006-01-02 15:04"),
+				Inline: true,
+			},
+		},
+	}
+
+	if msg.Content != "" {
+		truncated := []rune(msg.Content)
+		if len(truncated) > 500 {
+			truncated = truncated[:500]
+		}
+		embed.Description = strings.TrimSpace(string(truncated))
+	}
+
+	if jumpURL != "" {
+		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+			Name:  "元メッセージ",
+			Value: fmt.Sprintf("[リンクはこちら](%s)", jumpURL),
+		})
+	}
+
+	if imageURL := firstImageURL(msg); imageURL != "" {
+		embed.Image = &discordgo.MessageEmbedImage{URL: imageURL}
+	}
+
+	return &discordgo.MessageSend{
+		Embeds: []*discordgo.MessageEmbed{embed},
+		Components: []discordgo.MessageComponent{
+			discordgo.ActionsRow{Components: []discordgo.MessageComponent{
+				discordgo.Button{
+					Label:    "完了",
+					Style:    discordgo.SuccessButton,
+					CustomID: CompleteButtonID,
+					Emoji:    discordgo.ComponentEmoji{Name: "✅"},
+				},
+				discordgo.Button{
+					Label:    "削除",
+					Style:    discordgo.DangerButton,
+					CustomID: DeleteButtonID,
+					Emoji:    discordgo.ComponentEmoji{Name: "🗑️"},
+				},
+			}},
+		},
+	}
+}
+
+func buildCompleteBookmark(msg *discordgo.Message, channelName, jumpURL string, color int) *discordgo.MessageSend {
+	infoEmbed := buildInfoEmbed("📌 完全保存", msg, channelName, jumpURL, color, true)
+
+	embeds := []*discordgo.MessageEmbed{infoEmbed}
+	for _, e := range msg.Embeds {
+		if e == nil {
+			continue
+		}
+		embeds = append(embeds, cloneEmbed(e))
+	}
+
+	components := []discordgo.MessageComponent{
+		discordgo.ActionsRow{Components: []discordgo.MessageComponent{
+			discordgo.Button{
+				Style: discordgo.LinkButton,
+				Label: "元メッセージ",
+				URL:   jumpURL,
+				Emoji: discordgo.ComponentEmoji{Name: "🔗"},
+			},
+			discordgo.Button{
+				Label:    "削除",
+				Style:    discordgo.DangerButton,
+				CustomID: DeleteButtonID,
+				Emoji:    discordgo.ComponentEmoji{Name: "🗑️"},
+			},
+		}},
+	}
+
+	return &discordgo.MessageSend{
+		Embeds:     embeds,
+		Components: components,
+	}
+}
+
+func buildBalancedBookmark(msg *discordgo.Message, channelName, jumpURL string, color int) *discordgo.MessageSend {
+	infoEmbed := buildInfoEmbed("🔖 ブックマーク", msg, channelName, jumpURL, color, false)
+
+	embeds := []*discordgo.MessageEmbed{infoEmbed}
+	if len(msg.Embeds) == 1 && msg.Embeds[0] != nil {
+		embeds = append(embeds, cloneEmbed(msg.Embeds[0]))
+	}
+
+	return &discordgo.MessageSend{
+		Embeds: embeds,
+		Components: []discordgo.MessageComponent{
+			discordgo.ActionsRow{Components: []discordgo.MessageComponent{
+				discordgo.Button{
+					Label:    "削除",
+					Style:    discordgo.DangerButton,
+					CustomID: DeleteButtonID,
+					Emoji:    discordgo.ComponentEmoji{Name: "🗑️"},
+				},
+			}},
+		},
+	}
+}
+
+func buildInfoEmbed(title string, msg *discordgo.Message, channelName, jumpURL string, color int, includeAllAttachments bool) *discordgo.MessageEmbed {
+	embed := &discordgo.MessageEmbed{
+		Title: title,
+		Color: color,
+		Fields: []*discordgo.MessageEmbedField{
+			{
+				Name:   "投稿者",
 				Value:  msg.Author.String(),
 				Inline: true,
 			},
 			{
-				Name:   "Channel",
+				Name:   "チャンネル",
 				Value:  fmt.Sprintf("#%s", channelName),
+				Inline: true,
+			},
+			{
+				Name:   "投稿日",
+				Value:  msg.Timestamp.Format("2006-01-02 15:04"),
 				Inline: true,
 			},
 		},
@@ -128,33 +266,88 @@ func buildForwardedMessageEmbed(msg *discordgo.Message, channelName, jumpURL str
 
 	if jumpURL != "" {
 		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
-			Name:  "Jump to message",
-			Value: fmt.Sprintf("[Open original message](%s)", jumpURL),
+			Name:  "元メッセージ",
+			Value: fmt.Sprintf("[Jump](%s)", jumpURL),
 		})
 	}
 
-	if len(msg.Attachments) > 0 {
-		var attachments []string
-		for _, attachment := range msg.Attachments {
-			name := attachment.Filename
-			if name == "" {
-				name = attachment.URL
-			}
-			attachments = append(attachments, fmt.Sprintf("[%s](%s)", name, attachment.URL))
-		}
-
-		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
-			Name:  "Attachments",
-			Value: strings.Join(attachments, "\n"),
-		})
+	attachments := buildAttachmentField(msg.Attachments, includeAllAttachments)
+	if attachments != nil {
+		embed.Fields = append(embed.Fields, attachments)
 	}
 
 	return embed
 }
 
-func emojiMatches(emojis []string, value string) bool {
-	for _, emoji := range emojis {
-		if emoji == value {
+func buildAttachmentField(attachments []*discordgo.MessageAttachment, includeAll bool) *discordgo.MessageEmbedField {
+	if len(attachments) == 0 {
+		return nil
+	}
+
+	limit := len(attachments)
+	if !includeAll && limit > 3 {
+		limit = 3
+	}
+
+	var entries []string
+	for idx, attachment := range attachments {
+		if idx >= limit {
+			break
+		}
+
+		name := attachment.Filename
+		if name == "" {
+			name = attachment.URL
+		}
+		entries = append(entries, fmt.Sprintf("[%s](%s)", name, attachment.URL))
+	}
+
+	if !includeAll && len(attachments) > limit {
+		remaining := len(attachments) - limit
+		entries = append(entries, fmt.Sprintf("ほか%d件", remaining))
+	}
+
+	return &discordgo.MessageEmbedField{
+		Name:  "添付ファイル",
+		Value: strings.Join(entries, "\n"),
+	}
+}
+
+func firstImageURL(msg *discordgo.Message) string {
+	for _, attachment := range msg.Attachments {
+		if isImageAttachment(attachment) {
+			return attachment.URL
+		}
+	}
+
+	for _, embed := range msg.Embeds {
+		if embed == nil {
+			continue
+		}
+		if embed.Image != nil && embed.Image.URL != "" {
+			return embed.Image.URL
+		}
+		if embed.Thumbnail != nil && embed.Thumbnail.URL != "" {
+			return embed.Thumbnail.URL
+		}
+	}
+
+	return ""
+}
+
+func isImageAttachment(attachment *discordgo.MessageAttachment) bool {
+	if attachment == nil {
+		return false
+	}
+
+	if strings.HasPrefix(attachment.ContentType, "image/") {
+		return true
+	}
+
+	lower := strings.ToLower(attachment.Filename)
+	imageExts := []string{".png", ".jpg", ".jpeg", ".gif", ".webp"}
+	for _, ext := range imageExts {
+		if strings.HasSuffix(lower, ext) {
 			return true
 		}
 	}
@@ -162,10 +355,70 @@ func emojiMatches(emojis []string, value string) bool {
 	return false
 }
 
-func buildJumpLink(guildID, channelID, messageID string) string {
-	if guildID == "" {
-		return fmt.Sprintf("https://discord.com/channels/@me/%s/%s", channelID, messageID)
+func cloneEmbed(embed *discordgo.MessageEmbed) *discordgo.MessageEmbed {
+	if embed == nil {
+		return nil
 	}
 
-	return fmt.Sprintf("https://discord.com/channels/%s/%s/%s", guildID, channelID, messageID)
+	cloned := *embed
+
+	if embed.Fields != nil {
+		cloned.Fields = make([]*discordgo.MessageEmbedField, len(embed.Fields))
+		for i, field := range embed.Fields {
+			if field == nil {
+				continue
+			}
+			copied := *field
+			cloned.Fields[i] = &copied
+		}
+	}
+
+	if embed.Author != nil {
+		copied := *embed.Author
+		cloned.Author = &copied
+	}
+
+	if embed.Footer != nil {
+		copied := *embed.Footer
+		cloned.Footer = &copied
+	}
+
+	if embed.Image != nil {
+		copied := *embed.Image
+		cloned.Image = &copied
+	}
+
+	if embed.Thumbnail != nil {
+		copied := *embed.Thumbnail
+		cloned.Thumbnail = &copied
+	}
+
+	if embed.Provider != nil {
+		copied := *embed.Provider
+		cloned.Provider = &copied
+	}
+
+	if embed.Video != nil {
+		copied := *embed.Video
+		cloned.Video = &copied
+	}
+
+	if embed.Color != 0 {
+		cloned.Color = embed.Color
+	}
+
+	if embed.Timestamp != "" {
+		cloned.Timestamp = embed.Timestamp
+	}
+
+	if embed.Fields != nil {
+		// Already handled above but ensure nil entries remain nil.
+		for i, field := range embed.Fields {
+			if field == nil {
+				cloned.Fields[i] = nil
+			}
+		}
+	}
+
+	return &cloned
 }

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -2,11 +2,28 @@ package store
 
 import "sync"
 
-// UserPreferences stores the emoji and presentation configuration for a user.
-type UserPreferences struct {
-	Emojis   []string
+// BookmarkMode identifies how a bookmarked message should be formatted.
+type BookmarkMode string
+
+const (
+	// ModeLightweight stores a condensed embed focused on quick review.
+	ModeLightweight BookmarkMode = "lightweight"
+	// ModeComplete stores all available information from the original message.
+	ModeComplete BookmarkMode = "complete"
+	// ModeBalanced stores a balanced view between lightweight and complete.
+	ModeBalanced BookmarkMode = "balanced"
+)
+
+// EmojiPreference stores configuration for a specific emoji bookmark.
+type EmojiPreference struct {
+	Mode     BookmarkMode
 	Color    int
 	HasColor bool
+}
+
+// UserPreferences stores the emoji and presentation configuration for a user.
+type UserPreferences struct {
+	Emojis map[string]EmojiPreference
 }
 
 // EmojiStore provides thread-safe storage for user specific emoji preferences.
@@ -22,11 +39,17 @@ func NewEmojiStore() *EmojiStore {
 	}
 }
 
-// Set associates emoji preferences with a given user ID.
-func (s *EmojiStore) Set(userID string, prefs UserPreferences) {
+// SetEmoji associates emoji preferences with a given user ID and emoji.
+func (s *EmojiStore) SetEmoji(userID, emoji string, pref EmojiPreference) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.prefs[userID] = prefs
+	userPrefs, ok := s.prefs[userID]
+	if !ok || userPrefs.Emojis == nil {
+		userPrefs = UserPreferences{Emojis: make(map[string]EmojiPreference)}
+	}
+
+	userPrefs.Emojis[emoji] = pref
+	s.prefs[userID] = userPrefs
 }
 
 // Get retrieves the preferences associated with the user ID, if any.
@@ -34,5 +57,28 @@ func (s *EmojiStore) Get(userID string) (UserPreferences, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	prefs, ok := s.prefs[userID]
-	return prefs, ok
+	if !ok {
+		return UserPreferences{}, false
+	}
+
+	// Ensure the map is non-nil for consumers.
+	if prefs.Emojis == nil {
+		prefs.Emojis = make(map[string]EmojiPreference)
+	}
+
+	return prefs, true
+}
+
+// GetEmoji retrieves a specific emoji preference for the given user.
+func (s *EmojiStore) GetEmoji(userID, emoji string) (EmojiPreference, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	prefs, ok := s.prefs[userID]
+	if !ok {
+		return EmojiPreference{}, false
+	}
+
+	pref, ok := prefs.Emojis[emoji]
+	return pref, ok
 }


### PR DESCRIPTION
## Summary
- add the `/set-bookmark` command that stores per-emoji bookmark modes and colors
- generate lightweight, balanced, and complete bookmark messages with tailored embeds and buttons
- refresh documentation to describe the new workflow and command usage

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dc657f3444833087ae0852217db5ff