### PR TITLE
Persist bookmark settings between restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This project is a Discord bot built with Go and [discordgo](https://github.com/b
 | `DISCORD_TOKEN` | Bot token |
 | `DISCORD_APP_ID` | Application ID |
 | `DISCORD_GUILD_ID` | (Optional) Guild ID to register the command. Empty registers globally |
+| `BOOKMARK_STORE_PATH` | (Optional) Path to persist user bookmark settings. Defaults to `bookmarks.json` |
 
 Use `.env.example` as a reference when configuring the environment.
 

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -28,7 +28,11 @@ func New(cfg *config.Config) (*Bot, error) {
 		return nil, err
 	}
 
-	emojiStore := store.NewEmojiStore()
+	emojiStore, err := store.NewEmojiStore(cfg.StorePath)
+	if err != nil {
+		return nil, err
+	}
+
 	registerCommand := commands.NewSetBookmarkCommand(emojiStore)
 	reactionHandler := handlers.NewReactionHandler(emojiStore)
 

--- a/internal/commands/register.go
+++ b/internal/commands/register.go
@@ -124,7 +124,9 @@ func (c *SetBookmarkCommand) Handle(s *discordgo.Session, i *discordgo.Interacti
 		return fmt.Errorf("unable to resolve user from interaction")
 	}
 
-	c.store.SetEmoji(user.ID, normalized, store.EmojiPreference{Mode: mode, Color: color, HasColor: hasColor})
+	if err := c.store.SetEmoji(user.ID, normalized, store.EmojiPreference{Mode: mode, Color: color, HasColor: hasColor}); err != nil {
+		return fmt.Errorf("failed to save emoji preference: %w", err)
+	}
 
 	response := fmt.Sprintf("Saved %s in %s mode. React with it to save messages to your DM!", emojiTokens[0], string(mode))
 	if hasColor {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,9 +7,10 @@ import (
 
 // Config holds runtime configuration values loaded from environment variables.
 type Config struct {
-	BotToken string
-	AppID    string
-	GuildID  string
+	BotToken  string
+	AppID     string
+	GuildID   string
+	StorePath string
 }
 
 // Load reads configuration from environment variables and validates that the required
@@ -27,9 +28,15 @@ func Load() (*Config, error) {
 
 	guildID := os.Getenv("DISCORD_GUILD_ID")
 
+	storePath := os.Getenv("BOOKMARK_STORE_PATH")
+	if storePath == "" {
+		storePath = "bookmarks.json"
+	}
+
 	return &Config{
-		BotToken: token,
-		AppID:    appID,
-		GuildID:  guildID,
+		BotToken:  token,
+		AppID:     appID,
+		GuildID:   guildID,
+		StorePath: storePath,
 	}, nil
 }


### PR DESCRIPTION
## Summary
- persist emoji bookmark preferences to disk using a JSON-backed emoji store
- load saved preferences when the bot starts and return errors if persistence fails
- document the new `BOOKMARK_STORE_PATH` configuration option

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dc9d6432b48330a873d25c70c7ea8b