### PR TITLE
Persist scheduled reminders between bot restarts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 DISCORD_TOKEN=your-bot-token
 DISCORD_APP_ID=your-app-id
 # DISCORD_GUILD_ID=optional-guild-id
+# BOOKMARK_STORE_PATH=bookmarks.json
+# REMINDER_STORE_PATH=reminders.json

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This project is a Discord bot built with Go and [discordgo](https://github.com/b
 | `DISCORD_APP_ID` | Application ID |
 | `DISCORD_GUILD_ID` | (Optional) Guild ID to register the command. Empty registers globally |
 | `BOOKMARK_STORE_PATH` | (Optional) Path to persist user bookmark settings. Defaults to `bookmarks.json` |
+| `REMINDER_STORE_PATH` | (Optional) Path to persist scheduled reminders. Defaults to `reminders.json` |
 
 Use `.env.example` as a reference when configuring the environment.
 

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -38,7 +38,10 @@ func New(cfg *config.Config) (*Bot, error) {
 		return nil, err
 	}
 
-	reminderService := reminders.NewService(session)
+	reminderService, err := reminders.NewService(session, cfg.ReminderStorePath)
+	if err != nil {
+		return nil, err
+	}
 
 	registerCommand := commands.NewSetBookmarkCommand(emojiStore)
 	listCommand := commands.NewListBookmarksCommand(emojiStore)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,10 +7,11 @@ import (
 
 // Config holds runtime configuration values loaded from environment variables.
 type Config struct {
-	BotToken  string
-	AppID     string
-	GuildID   string
-	StorePath string
+	BotToken          string
+	AppID             string
+	GuildID           string
+	StorePath         string
+	ReminderStorePath string
 }
 
 // Load reads configuration from environment variables and validates that the required
@@ -33,10 +34,16 @@ func Load() (*Config, error) {
 		storePath = "bookmarks.json"
 	}
 
+	reminderStorePath := os.Getenv("REMINDER_STORE_PATH")
+	if reminderStorePath == "" {
+		reminderStorePath = "reminders.json"
+	}
+
 	return &Config{
-		BotToken:  token,
-		AppID:     appID,
-		GuildID:   guildID,
-		StorePath: storePath,
+		BotToken:          token,
+		AppID:             appID,
+		GuildID:           guildID,
+		StorePath:         storePath,
+		ReminderStorePath: reminderStorePath,
 	}, nil
 }

--- a/internal/reminders/service.go
+++ b/internal/reminders/service.go
@@ -1,8 +1,13 @@
 package reminders
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"log"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -20,6 +25,7 @@ type Payload struct {
 
 type scheduledReminder struct {
 	timer            *time.Timer
+	when             time.Time
 	removeOnComplete bool
 	payload          Payload
 }
@@ -29,14 +35,28 @@ type Service struct {
 	session   *discordgo.Session
 	mu        sync.Mutex
 	scheduled map[string]*scheduledReminder
+	filePath  string
+}
+
+type persistedReminder struct {
+	When             string  `json:"when"`
+	RemoveOnComplete bool    `json:"removeOnComplete"`
+	Payload          Payload `json:"payload"`
 }
 
 // NewService constructs a reminder service bound to the provided Discord session.
-func NewService(session *discordgo.Session) *Service {
-	return &Service{
+func NewService(session *discordgo.Session, filePath string) (*Service, error) {
+	service := &Service{
 		session:   session,
 		scheduled: make(map[string]*scheduledReminder),
+		filePath:  filePath,
 	}
+
+	if err := service.restore(); err != nil {
+		return nil, err
+	}
+
+	return service, nil
 }
 
 // Schedule registers a reminder for the given bookmark message ID.
@@ -45,25 +65,11 @@ func (s *Service) Schedule(messageID string, when time.Time, payload Payload, re
 		return
 	}
 
-	delay := time.Until(when)
-	if delay <= 0 {
-		delay = time.Second
-	}
-
 	s.mu.Lock()
-	if existing, ok := s.scheduled[messageID]; ok {
-		existing.timer.Stop()
+	s.scheduleLocked(messageID, when, payload, removeOnComplete)
+	if err := s.persistLocked(); err != nil {
+		log.Printf("failed to persist reminders: %v", err)
 	}
-
-	reminder := &scheduledReminder{
-		removeOnComplete: removeOnComplete,
-		payload:          payload,
-	}
-	reminder.timer = time.AfterFunc(delay, func() {
-		s.deliver(messageID)
-	})
-
-	s.scheduled[messageID] = reminder
 	s.mu.Unlock()
 }
 
@@ -72,8 +78,13 @@ func (s *Service) Cancel(messageID string) {
 	s.mu.Lock()
 	reminder, ok := s.scheduled[messageID]
 	if ok {
-		reminder.timer.Stop()
+		if reminder.timer != nil {
+			reminder.timer.Stop()
+		}
 		delete(s.scheduled, messageID)
+		if err := s.persistLocked(); err != nil {
+			log.Printf("failed to persist reminders: %v", err)
+		}
 	}
 	s.mu.Unlock()
 }
@@ -95,9 +106,11 @@ func (s *Service) Complete(messageID string) {
 // Close stops all scheduled reminders. It should be called during shutdown to prevent dangling timers.
 func (s *Service) Close() {
 	s.mu.Lock()
-	for id, reminder := range s.scheduled {
-		reminder.timer.Stop()
-		delete(s.scheduled, id)
+	for _, reminder := range s.scheduled {
+		if reminder.timer != nil {
+			reminder.timer.Stop()
+		}
+		reminder.timer = nil
 	}
 	s.mu.Unlock()
 }
@@ -107,6 +120,9 @@ func (s *Service) deliver(messageID string) {
 	reminder, ok := s.scheduled[messageID]
 	if ok {
 		delete(s.scheduled, messageID)
+		if err := s.persistLocked(); err != nil {
+			log.Printf("failed to persist reminders: %v", err)
+		}
 	}
 	s.mu.Unlock()
 
@@ -148,4 +164,127 @@ func (s *Service) deliver(messageID string) {
 	if err != nil {
 		log.Printf("failed to deliver reminder: %v", err)
 	}
+}
+
+func (s *Service) scheduleLocked(messageID string, when time.Time, payload Payload, removeOnComplete bool) {
+	delay := time.Until(when)
+	if delay <= 0 {
+		delay = time.Second
+	}
+
+	if existing, ok := s.scheduled[messageID]; ok {
+		if existing.timer != nil {
+			existing.timer.Stop()
+		}
+	}
+
+	reminder := &scheduledReminder{
+		removeOnComplete: removeOnComplete,
+		payload:          payload,
+	}
+	reminder.when = time.Now().Add(delay)
+	reminder.timer = time.AfterFunc(delay, func() {
+		s.deliver(messageID)
+	})
+
+	s.scheduled[messageID] = reminder
+}
+
+func (s *Service) restore() error {
+	if s.filePath == "" {
+		return nil
+	}
+
+	file, err := os.Open(s.filePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	defer file.Close()
+
+	decoder := json.NewDecoder(file)
+	var persisted map[string]persistedReminder
+	if err := decoder.Decode(&persisted); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		return err
+	}
+
+	now := time.Now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for messageID, stored := range persisted {
+		when, err := time.Parse(time.RFC3339Nano, stored.When)
+		if err != nil {
+			log.Printf("failed to parse reminder time for %s: %v", messageID, err)
+			continue
+		}
+		if !when.After(now) {
+			when = now.Add(time.Second)
+		}
+		s.scheduleLocked(messageID, when, stored.Payload, stored.RemoveOnComplete)
+	}
+
+	return nil
+}
+
+func (s *Service) persistLocked() error {
+	if s.filePath == "" {
+		return nil
+	}
+
+	toPersist := make(map[string]persistedReminder, len(s.scheduled))
+	for id, reminder := range s.scheduled {
+		if reminder == nil {
+			continue
+		}
+
+		when := reminder.when
+		if when.IsZero() {
+			when = time.Now().Add(time.Second)
+		}
+
+		toPersist[id] = persistedReminder{
+			When:             when.Format(time.RFC3339Nano),
+			RemoveOnComplete: reminder.removeOnComplete,
+			Payload:          reminder.payload,
+		}
+	}
+
+	dir := filepath.Dir(s.filePath)
+	if dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+
+	tempFile, err := os.CreateTemp(dir, "reminders-*.json")
+	if err != nil {
+		return err
+	}
+
+	encoder := json.NewEncoder(tempFile)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(toPersist); err != nil {
+		tempFile.Close()
+		os.Remove(tempFile.Name())
+		return err
+	}
+
+	if err := tempFile.Close(); err != nil {
+		os.Remove(tempFile.Name())
+		return err
+	}
+
+	if err := os.Rename(tempFile.Name(), s.filePath); err != nil {
+		os.Remove(tempFile.Name())
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary
- add JSON persistence to the reminder service and reload reminders on startup
- make the reminder store path configurable via the new `REMINDER_STORE_PATH` environment variable
- document the reminder persistence settings in the README and `.env` example

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dcdde5b000833093d28a0406c1775a