### PR TITLE
Ensure reminder bookmarks expose completion button across modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Discord Message Saver Bot
+# Discord Bookmark Manager
 
 This project is a Discord bot built with Go and [discordgo](https://github.com/bwmarrin/discordgo). Users can associate multiple emojis with different bookmark modes and, when they react to a message with one of those emojis, the bot forwards the message to their DM with the appropriate layout and controls.
 

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -6,8 +6,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/example/discord-simple-reading-list/internal/bot"
-	"github.com/example/discord-simple-reading-list/internal/config"
+	"github.com/example/discord-bookmark-manager/internal/bot"
+	"github.com/example/discord-bookmark-manager/internal/config"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/example/discord-simple-reading-list
+module github.com/example/discord-bookmark-manager
 
 go 1.24.3
 

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 
-	"github.com/example/discord-simple-reading-list/internal/commands"
-	"github.com/example/discord-simple-reading-list/internal/config"
-	"github.com/example/discord-simple-reading-list/internal/handlers"
-	"github.com/example/discord-simple-reading-list/internal/reminders"
-	"github.com/example/discord-simple-reading-list/internal/store"
+	"github.com/example/discord-bookmark-manager/internal/commands"
+	"github.com/example/discord-bookmark-manager/internal/config"
+	"github.com/example/discord-bookmark-manager/internal/handlers"
+	"github.com/example/discord-bookmark-manager/internal/reminders"
+	"github.com/example/discord-bookmark-manager/internal/store"
 )
 
 // Bot encapsulates the Discord session and all registered handlers.

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 
-	"github.com/example/discord-simple-reading-list/internal/reminders"
-	"github.com/example/discord-simple-reading-list/internal/store"
+	"github.com/example/discord-bookmark-manager/internal/reminders"
+	"github.com/example/discord-bookmark-manager/internal/store"
 )
 
 // ListBookmarksCommandName identifies the slash command that shows saved bookmark preferences.

--- a/internal/commands/register.go
+++ b/internal/commands/register.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 
-	"github.com/example/discord-simple-reading-list/internal/reminders"
-	"github.com/example/discord-simple-reading-list/internal/store"
+	"github.com/example/discord-bookmark-manager/internal/reminders"
+	"github.com/example/discord-bookmark-manager/internal/store"
 )
 
 // SetBookmarkCommandName identifies the slash command for selecting the bookmark reaction emoji and mode.

--- a/internal/handlers/components.go
+++ b/internal/handlers/components.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 
-	"github.com/example/discord-simple-reading-list/internal/reminders"
+	"github.com/example/discord-bookmark-manager/internal/reminders"
 )
 
 // CompleteButtonID identifies the button that marks a lightweight bookmark as complete.

--- a/internal/handlers/reaction.go
+++ b/internal/handlers/reaction.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 
-	"github.com/example/discord-simple-reading-list/internal/reminders"
-	"github.com/example/discord-simple-reading-list/internal/store"
+	"github.com/example/discord-bookmark-manager/internal/reminders"
+	"github.com/example/discord-bookmark-manager/internal/store"
 )
 
 const defaultEmbedColor = 0x5865F2
@@ -229,22 +229,33 @@ func buildCompleteBookmark(msg *discordgo.Message, channelName, jumpURL string, 
 		embeds = append(embeds, cloneEmbed(e))
 	}
 
-	components := []discordgo.MessageComponent{
-		discordgo.ActionsRow{Components: []discordgo.MessageComponent{
-			discordgo.Button{
-				Style: discordgo.LinkButton,
-				Label: "元メッセージ",
-				URL:   jumpURL,
-				Emoji: discordgo.ComponentEmoji{Name: "🔗"},
-			},
-			discordgo.Button{
-				Label:    "削除",
-				Style:    discordgo.DangerButton,
-				CustomID: DeleteButtonID,
-				Emoji:    discordgo.ComponentEmoji{Name: "🗑️"},
-			},
-		}},
+	components := []discordgo.MessageComponent{}
+	buttons := []discordgo.MessageComponent{
+		discordgo.Button{
+			Style: discordgo.LinkButton,
+			Label: "元メッセージ",
+			URL:   jumpURL,
+			Emoji: discordgo.ComponentEmoji{Name: "🔗"},
+		},
 	}
+
+	if schedule != nil {
+		buttons = append(buttons, discordgo.Button{
+			Label:    "完了",
+			Style:    discordgo.SuccessButton,
+			CustomID: CompleteButtonID,
+			Emoji:    discordgo.ComponentEmoji{Name: "✅"},
+		})
+	}
+
+	buttons = append(buttons, discordgo.Button{
+		Label:    "削除",
+		Style:    discordgo.DangerButton,
+		CustomID: DeleteButtonID,
+		Emoji:    discordgo.ComponentEmoji{Name: "🗑️"},
+	})
+
+	components = append(components, discordgo.ActionsRow{Components: buttons})
 
 	return &discordgo.MessageSend{
 		Embeds:     embeds,
@@ -260,17 +271,28 @@ func buildBalancedBookmark(msg *discordgo.Message, channelName, jumpURL string, 
 		embeds = append(embeds, cloneEmbed(msg.Embeds[0]))
 	}
 
+	buttons := []discordgo.MessageComponent{}
+
+	if schedule != nil {
+		buttons = append(buttons, discordgo.Button{
+			Label:    "完了",
+			Style:    discordgo.SuccessButton,
+			CustomID: CompleteButtonID,
+			Emoji:    discordgo.ComponentEmoji{Name: "✅"},
+		})
+	}
+
+	buttons = append(buttons, discordgo.Button{
+		Label:    "削除",
+		Style:    discordgo.DangerButton,
+		CustomID: DeleteButtonID,
+		Emoji:    discordgo.ComponentEmoji{Name: "🗑️"},
+	})
+
 	return &discordgo.MessageSend{
 		Embeds: embeds,
 		Components: []discordgo.MessageComponent{
-			discordgo.ActionsRow{Components: []discordgo.MessageComponent{
-				discordgo.Button{
-					Label:    "削除",
-					Style:    discordgo.DangerButton,
-					CustomID: DeleteButtonID,
-					Emoji:    discordgo.ComponentEmoji{Name: "🗑️"},
-				},
-			}},
+			discordgo.ActionsRow{Components: buttons},
 		},
 	}
 }

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/example/discord-simple-reading-list/internal/reminders"
+	"github.com/example/discord-bookmark-manager/internal/reminders"
 )
 
 // BookmarkMode identifies how a bookmarked message should be formatted.


### PR DESCRIPTION
## Summary
- show the ✅ 完了 button on balanced and complete bookmark layouts when a reminder is scheduled
- rename the module and import paths to github.com/example/discord-bookmark-manager to match the repository naming
- update the README title to reflect the new Discord Bookmark Manager name

## Testing
- go test ./internal/...


------
https://chatgpt.com/codex/tasks/task_e_68dcfa0e610c833095002078a38be91b