### PR TITLE
Add remove bookmark command and translate bot messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This project is a Discord bot built with Go and [discordgo](https://github.com/bwmarrin/discordgo). Users can associate multiple emojis with different bookmark modes and, when they react to a message with one of those emojis, the bot forwards the message to their DM with the appropriate layout and controls.
 
+## What you can do
+
+- React with an emoji to file a message into your DM with tailored layouts.
+- Pick between quick, balanced, or full-detail bookmark styles with custom colors.
+- Schedule reminders and decide whether they clear when you mark a bookmark as done.
+- Add, list, and remove emoji shortcuts with slash commands.
+
 ## Requirements
 
 - Go 1.20+
@@ -38,7 +45,7 @@ docker compose up --build
 2. `/list-bookmarks` shows the emojis you have configured and their associated modes and colors.
 3. `/bookmark-help` provides a quick reference for the available commands and how to use them.
 4. Reacting with any registered emoji forwards the message to your DM using the configured mode (lightweight, balanced, or complete).
-5. Saved messages include mode-specific action buttons such as ✅ 完了, 🗑️ 削除, and 🔗 元メッセージ.
+5. Saved messages include mode-specific action buttons such as ✅ Done, 🗑️ Remove, and 🔗 Source.
 
 The bot registers the slash command automatically when it starts, so no additional registration command is required.
 
@@ -52,6 +59,7 @@ Use the following format when customising the bookmark behaviour:
 /set-bookmark emoji:📌 mode:complete color:#FF6B6B
 /set-bookmark emoji:⏰ mode:lightweight reminder:8:00
 /set-bookmark emoji:⏰ mode:lightweight reminder:45m keep-reminder-on-complete:true
+/remove-bookmark emoji:👀
 /list-bookmarks
 /bookmark-help
 ```
@@ -61,4 +69,4 @@ Use the following format when customising the bookmark behaviour:
 - The optional `color` argument accepts a 6-digit hex value with or without `#`/`0x` prefixes. Leave it out to fall back to the bot default.
 - Use the optional `reminder` argument to schedule a reminder for each saved message. Supply either a time of day such as `08:00` or a duration like `30m`/`2h`.
 - When a reminder is set, the saved DM includes the next reminder time. Reminders can be cleared with `reminder:none`.
-- Add `keep-reminder-on-complete:true` if you want the reminder to remain active after pressing the ✅ 完了 button. By default the reminder is removed when the bookmark is marked as complete.
+- Add `keep-reminder-on-complete:true` if you want the reminder to remain active after pressing the ✅ Done button. By default the reminder is removed when the bookmark is marked as complete.

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -18,6 +18,7 @@ type Bot struct {
 	config          *config.Config
 	store           *store.EmojiStore
 	registerCmd     *commands.SetBookmarkCommand
+	removeCmd       *commands.RemoveBookmarkCommand
 	listCmd         *commands.ListBookmarksCommand
 	helpCmd         *commands.HelpCommand
 	reactionHandle  *handlers.ReactionHandler
@@ -44,6 +45,7 @@ func New(cfg *config.Config) (*Bot, error) {
 	}
 
 	registerCommand := commands.NewSetBookmarkCommand(emojiStore)
+	removeCommand := commands.NewRemoveBookmarkCommand(emojiStore)
 	listCommand := commands.NewListBookmarksCommand(emojiStore)
 	helpCommand := commands.NewHelpCommand()
 	reactionHandler := handlers.NewReactionHandler(emojiStore, reminderService)
@@ -54,6 +56,7 @@ func New(cfg *config.Config) (*Bot, error) {
 		config:          cfg,
 		store:           emojiStore,
 		registerCmd:     registerCommand,
+		removeCmd:       removeCommand,
 		listCmd:         listCommand,
 		helpCmd:         helpCommand,
 		reactionHandle:  reactionHandler,
@@ -108,6 +111,7 @@ func (b *Bot) Close() error {
 func (b *Bot) registerCommands() error {
 	definitions := []*discordgo.ApplicationCommand{
 		b.registerCmd.Definition(),
+		b.removeCmd.Definition(),
 		b.listCmd.Definition(),
 		b.helpCmd.Definition(),
 	}
@@ -131,6 +135,10 @@ func (b *Bot) onInteraction(s *discordgo.Session, i *discordgo.InteractionCreate
 		case commands.SetBookmarkCommandName:
 			if err := b.registerCmd.Handle(s, i); err != nil {
 				log.Printf("failed to handle register command: %v", err)
+			}
+		case commands.RemoveBookmarkCommandName:
+			if err := b.removeCmd.Handle(s, i); err != nil {
+				log.Printf("failed to handle remove command: %v", err)
 			}
 		case commands.ListBookmarksCommandName:
 			if err := b.listCmd.Handle(s, i); err != nil {

--- a/internal/commands/help.go
+++ b/internal/commands/help.go
@@ -27,12 +27,13 @@ func (c *HelpCommand) Handle(s *discordgo.Session, i *discordgo.InteractionCreat
 		return nil
 	}
 
-	helpText := "ブックマークボットの使い方:\n" +
-		"• `/set-bookmark emoji:😊 mode:lightweight color:#FFD700` — 絵文字に保存モードと色を割り当てます。\n" +
-		"• `/set-bookmark emoji:⏰ mode:lightweight reminder:8:00` — リマインドする時刻や `30m` のような時間を設定できます。\n" +
-		"  完了ボタンでリマインドを残したい場合は `keep-reminder-on-complete:true` を追加してください。\n" +
-		"• `/list-bookmarks` — 現在登録している絵文字とモードを確認できます。\n" +
-		"メッセージに指定した絵文字でリアクションすると、設定したモードでDMに送信されます。"
+	helpText := "🛠️ Bookmark bot quick guide:\n" +
+		"• `/set-bookmark emoji:😊 mode:lightweight color:#FFD700` — Assign a save mode and embed color to an emoji.\n" +
+		"• `/set-bookmark emoji:⏰ mode:lightweight reminder:8:00` — Add a reminder time or duration like `30m`.\n" +
+		"  Keep the reminder after tapping Done with `keep-reminder-on-complete:true`.\n" +
+		"• `/list-bookmarks` — Review every emoji shortcut you've saved.\n" +
+		"• `/remove-bookmark emoji:😊` — Delete an emoji shortcut you no longer need.\n" +
+		"React with a saved emoji to receive a DM in the layout you chose."
 
 	return respondEphemeral(s, i, helpText)
 }

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -48,7 +48,7 @@ func (c *ListBookmarksCommand) Handle(s *discordgo.Session, i *discordgo.Interac
 
 	prefs, ok := c.store.Get(user.ID)
 	if !ok || len(prefs.Emojis) == 0 {
-		return respondEphemeral(s, i, "まだブックマークは登録されていません。`/set-bookmark` コマンドで保存を始めましょう！")
+		return respondEphemeral(s, i, "📭 No bookmark emojis saved yet. Use `/set-bookmark` to create one!")
 	}
 
 	emojis := make([]string, 0, len(prefs.Emojis))
@@ -58,28 +58,28 @@ func (c *ListBookmarksCommand) Handle(s *discordgo.Session, i *discordgo.Interac
 	sort.Strings(emojis)
 
 	var builder strings.Builder
-	builder.WriteString("現在登録されているブックマーク設定:\n")
+	builder.WriteString("⭐ Saved bookmark shortcuts:\n")
 	for _, emoji := range emojis {
 		pref := prefs.Emojis[emoji]
 		display := formatEmojiForDisplay(emoji)
 		mode := string(pref.Mode)
-		colorDescription := "デフォルト"
+		colorDescription := "default"
 		if pref.HasColor {
 			colorDescription = fmt.Sprintf("#%06X", pref.Color)
 		}
-		builder.WriteString(fmt.Sprintf("• %s — %s モード (色: %s)\n", display, mode, colorDescription))
-		reminderLine := fmt.Sprintf("  ↳ リマインド: %s", reminders.Describe(pref.Reminder))
+		builder.WriteString(fmt.Sprintf("• %s — %s mode (color: %s)\n", display, mode, colorDescription))
+		reminderLine := fmt.Sprintf("  ↳ ⏰ Reminder: %s", reminders.Describe(pref.Reminder))
 		if pref.Reminder != nil {
 			if pref.Reminder.RemoveOnComplete {
-				reminderLine += " / 完了時に削除"
+				reminderLine += " / ✅ clears on Done"
 			} else {
-				reminderLine += " / 完了後も維持"
+				reminderLine += " / 🔁 stays after Done"
 			}
 		}
 		builder.WriteString(reminderLine + "\n")
 	}
 
-	builder.WriteString("\n設定を変更する場合は `/set-bookmark` を使用してください。")
+	builder.WriteString("\nUse `/set-bookmark` to tweak settings or `/remove-bookmark` to delete one.")
 
 	return respondEphemeral(s, i, builder.String())
 }

--- a/internal/commands/register.go
+++ b/internal/commands/register.go
@@ -163,7 +163,7 @@ func (c *SetBookmarkCommand) Handle(s *discordgo.Session, i *discordgo.Interacti
 
 		if parsedReminder == nil {
 			if keepProvided {
-				return fmt.Errorf("リマインドを削除する場合は keep-reminder-on-complete オプションは使用できません")
+				return fmt.Errorf("keep-reminder-on-complete cannot be used when removing a reminder")
 			}
 			reminderPref = nil
 		} else {
@@ -178,7 +178,7 @@ func (c *SetBookmarkCommand) Handle(s *discordgo.Session, i *discordgo.Interacti
 		}
 	} else if keepProvided {
 		if reminderPref == nil {
-			return fmt.Errorf("リマインドが設定されていないため keep-reminder-on-complete を変更できません。reminder オプションを設定してください。")
+			return fmt.Errorf("there is no reminder to update. Set the reminder option first.")
 		}
 		reminderPref.RemoveOnComplete = !keepReminder
 	}
@@ -208,9 +208,9 @@ func (c *SetBookmarkCommand) Handle(s *discordgo.Session, i *discordgo.Interacti
 	}
 	if reminderPref != nil {
 		if reminderPref.RemoveOnComplete {
-			response += " 完了ボタンでリマインドも削除されます。"
+			response += " ✅ The Done button will clear the reminder."
 		} else {
-			response += " 完了ボタンを押してもリマインドは残ります。"
+			response += " 🔁 The reminder stays active after Done."
 		}
 	}
 	return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{

--- a/internal/commands/remove.go
+++ b/internal/commands/remove.go
@@ -1,0 +1,91 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+
+	"github.com/example/discord-bookmark-manager/internal/store"
+)
+
+// RemoveBookmarkCommandName identifies the slash command used to delete saved bookmark emojis.
+const RemoveBookmarkCommandName = "remove-bookmark"
+
+// RemoveBookmarkCommand handles the `/remove-bookmark` slash command lifecycle.
+type RemoveBookmarkCommand struct {
+	store *store.EmojiStore
+}
+
+// NewRemoveBookmarkCommand constructs a new RemoveBookmarkCommand.
+func NewRemoveBookmarkCommand(store *store.EmojiStore) *RemoveBookmarkCommand {
+	return &RemoveBookmarkCommand{store: store}
+}
+
+// Definition returns the discordgo.ApplicationCommand definition for registration.
+func (c *RemoveBookmarkCommand) Definition() *discordgo.ApplicationCommand {
+	return &discordgo.ApplicationCommand{
+		Name:        RemoveBookmarkCommandName,
+		Description: "Delete a saved emoji shortcut",
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Type:        discordgo.ApplicationCommandOptionString,
+				Name:        "emoji",
+				Description: "Emoji to remove from your saved shortcuts",
+				Required:    true,
+			},
+		},
+	}
+}
+
+// Handle executes the command when invoked by a user.
+func (c *RemoveBookmarkCommand) Handle(s *discordgo.Session, i *discordgo.InteractionCreate) error {
+	if i.Type != discordgo.InteractionApplicationCommand {
+		return nil
+	}
+
+	options := i.ApplicationCommandData().Options
+	if len(options) == 0 {
+		return fmt.Errorf("emoji option is required")
+	}
+
+	rawEmoji := strings.TrimSpace(options[0].StringValue())
+	if rawEmoji == "" {
+		return fmt.Errorf("emoji option is required")
+	}
+
+	emojiTokens := splitEmojiInput(rawEmoji)
+	if len(emojiTokens) == 0 {
+		return fmt.Errorf("please provide an emoji")
+	}
+	if len(emojiTokens) != 1 {
+		return fmt.Errorf("please remove one emoji at a time")
+	}
+
+	normalized := normalizeEmoji(emojiTokens[0])
+	if normalized == "" {
+		return fmt.Errorf("please provide an emoji")
+	}
+
+	user := i.Member.User
+	if user == nil {
+		user = i.User
+	}
+	if user == nil {
+		return fmt.Errorf("unable to resolve user from interaction")
+	}
+
+	removed, err := c.store.DeleteEmoji(user.ID, normalized)
+	if err != nil {
+		return fmt.Errorf("failed to remove emoji preference: %w", err)
+	}
+
+	var content string
+	if !removed {
+		content = "⚠️ That emoji isn't saved yet. Use `/set-bookmark` to add it first."
+	} else {
+		content = fmt.Sprintf("🧹 Removed %s from your shortcuts.", formatEmojiForDisplay(emojiTokens[0]))
+	}
+
+	return respondEphemeral(s, i, content)
+}

--- a/internal/handlers/reaction.go
+++ b/internal/handlers/reaction.go
@@ -154,16 +154,16 @@ func buildLightweightBookmark(msg *discordgo.Message, channelName, jumpURL strin
 	}
 
 	embed := &discordgo.MessageEmbed{
-		Title: fmt.Sprintf("%s 後で読む", titleEmoji),
+		Title: fmt.Sprintf("%s Quick Read", titleEmoji),
 		Color: color,
 		Fields: []*discordgo.MessageEmbedField{
 			{
-				Name:   "チャンネル",
+				Name:   "📺 Channel",
 				Value:  fmt.Sprintf("#%s", channelName),
 				Inline: true,
 			},
 			{
-				Name:   "保存日時",
+				Name:   "💾 Saved",
 				Value:  time.Now().Format("2006-01-02 15:04"),
 				Inline: true,
 			},
@@ -172,7 +172,7 @@ func buildLightweightBookmark(msg *discordgo.Message, channelName, jumpURL strin
 
 	if schedule != nil {
 		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
-			Name:   "リマインド",
+			Name:   "⏰ Reminder",
 			Value:  schedule.Description,
 			Inline: true,
 		})
@@ -188,8 +188,8 @@ func buildLightweightBookmark(msg *discordgo.Message, channelName, jumpURL strin
 
 	if jumpURL != "" {
 		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
-			Name:  "元メッセージ",
-			Value: fmt.Sprintf("[リンクはこちら](%s)", jumpURL),
+			Name:  "🔗 Source Message",
+			Value: fmt.Sprintf("[Open](%s)", jumpURL),
 		})
 	}
 
@@ -202,13 +202,13 @@ func buildLightweightBookmark(msg *discordgo.Message, channelName, jumpURL strin
 		Components: []discordgo.MessageComponent{
 			discordgo.ActionsRow{Components: []discordgo.MessageComponent{
 				discordgo.Button{
-					Label:    "完了",
+					Label:    "Done",
 					Style:    discordgo.SuccessButton,
 					CustomID: CompleteButtonID,
 					Emoji:    discordgo.ComponentEmoji{Name: "✅"},
 				},
 				discordgo.Button{
-					Label:    "削除",
+					Label:    "Remove",
 					Style:    discordgo.DangerButton,
 					CustomID: DeleteButtonID,
 					Emoji:    discordgo.ComponentEmoji{Name: "🗑️"},
@@ -219,7 +219,7 @@ func buildLightweightBookmark(msg *discordgo.Message, channelName, jumpURL strin
 }
 
 func buildCompleteBookmark(msg *discordgo.Message, channelName, jumpURL string, color int, schedule *reminders.Schedule) *discordgo.MessageSend {
-	infoEmbed := buildInfoEmbed("📌 完全保存", msg, channelName, jumpURL, color, true, schedule)
+	infoEmbed := buildInfoEmbed("📌 Full Save", msg, channelName, jumpURL, color, true, schedule)
 
 	embeds := []*discordgo.MessageEmbed{infoEmbed}
 	for _, e := range msg.Embeds {
@@ -233,7 +233,7 @@ func buildCompleteBookmark(msg *discordgo.Message, channelName, jumpURL string, 
 	buttons := []discordgo.MessageComponent{
 		discordgo.Button{
 			Style: discordgo.LinkButton,
-			Label: "元メッセージ",
+			Label: "🔗 Source",
 			URL:   jumpURL,
 			Emoji: discordgo.ComponentEmoji{Name: "🔗"},
 		},
@@ -241,7 +241,7 @@ func buildCompleteBookmark(msg *discordgo.Message, channelName, jumpURL string, 
 
 	if schedule != nil {
 		buttons = append(buttons, discordgo.Button{
-			Label:    "完了",
+			Label:    "Done",
 			Style:    discordgo.SuccessButton,
 			CustomID: CompleteButtonID,
 			Emoji:    discordgo.ComponentEmoji{Name: "✅"},
@@ -249,7 +249,7 @@ func buildCompleteBookmark(msg *discordgo.Message, channelName, jumpURL string, 
 	}
 
 	buttons = append(buttons, discordgo.Button{
-		Label:    "削除",
+		Label:    "Remove",
 		Style:    discordgo.DangerButton,
 		CustomID: DeleteButtonID,
 		Emoji:    discordgo.ComponentEmoji{Name: "🗑️"},
@@ -264,7 +264,7 @@ func buildCompleteBookmark(msg *discordgo.Message, channelName, jumpURL string, 
 }
 
 func buildBalancedBookmark(msg *discordgo.Message, channelName, jumpURL string, color int, schedule *reminders.Schedule) *discordgo.MessageSend {
-	infoEmbed := buildInfoEmbed("🔖 ブックマーク", msg, channelName, jumpURL, color, false, schedule)
+	infoEmbed := buildInfoEmbed("🔖 Smart Save", msg, channelName, jumpURL, color, false, schedule)
 
 	embeds := []*discordgo.MessageEmbed{infoEmbed}
 	if len(msg.Embeds) == 1 && msg.Embeds[0] != nil {
@@ -275,7 +275,7 @@ func buildBalancedBookmark(msg *discordgo.Message, channelName, jumpURL string, 
 
 	if schedule != nil {
 		buttons = append(buttons, discordgo.Button{
-			Label:    "完了",
+			Label:    "Done",
 			Style:    discordgo.SuccessButton,
 			CustomID: CompleteButtonID,
 			Emoji:    discordgo.ComponentEmoji{Name: "✅"},
@@ -283,7 +283,7 @@ func buildBalancedBookmark(msg *discordgo.Message, channelName, jumpURL string, 
 	}
 
 	buttons = append(buttons, discordgo.Button{
-		Label:    "削除",
+		Label:    "Remove",
 		Style:    discordgo.DangerButton,
 		CustomID: DeleteButtonID,
 		Emoji:    discordgo.ComponentEmoji{Name: "🗑️"},
@@ -303,17 +303,17 @@ func buildInfoEmbed(title string, msg *discordgo.Message, channelName, jumpURL s
 		Color: color,
 		Fields: []*discordgo.MessageEmbedField{
 			{
-				Name:   "投稿者",
+				Name:   "🙋 Author",
 				Value:  msg.Author.String(),
 				Inline: true,
 			},
 			{
-				Name:   "チャンネル",
+				Name:   "📺 Channel",
 				Value:  fmt.Sprintf("#%s", channelName),
 				Inline: true,
 			},
 			{
-				Name:   "投稿日",
+				Name:   "🕓 Posted",
 				Value:  msg.Timestamp.Format("2006-01-02 15:04"),
 				Inline: true,
 			},
@@ -322,7 +322,7 @@ func buildInfoEmbed(title string, msg *discordgo.Message, channelName, jumpURL s
 
 	if schedule != nil {
 		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
-			Name:   "リマインド",
+			Name:   "⏰ Reminder",
 			Value:  schedule.Description,
 			Inline: true,
 		})
@@ -334,8 +334,8 @@ func buildInfoEmbed(title string, msg *discordgo.Message, channelName, jumpURL s
 
 	if jumpURL != "" {
 		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
-			Name:  "元メッセージ",
-			Value: fmt.Sprintf("[Jump](%s)", jumpURL),
+			Name:  "🔗 Source Message",
+			Value: fmt.Sprintf("[Open](%s)", jumpURL),
 		})
 	}
 
@@ -372,11 +372,11 @@ func buildAttachmentField(attachments []*discordgo.MessageAttachment, includeAll
 
 	if !includeAll && len(attachments) > limit {
 		remaining := len(attachments) - limit
-		entries = append(entries, fmt.Sprintf("ほか%d件", remaining))
+		entries = append(entries, fmt.Sprintf("… +%d more", remaining))
 	}
 
 	return &discordgo.MessageEmbedField{
-		Name:  "添付ファイル",
+		Name:  "🖇️ Attachments",
 		Value: strings.Join(entries, "\n"),
 	}
 }

--- a/internal/reminders/service.go
+++ b/internal/reminders/service.go
@@ -131,30 +131,30 @@ func (s *Service) deliver(messageID string) {
 	}
 
 	embed := &discordgo.MessageEmbed{
-		Title:       "⏰ リマインド",
-		Description: fmt.Sprintf("#%s のメッセージを確認しましょう。", reminder.payload.ChannelName),
+		Title:       "⏰ Reminder",
+		Description: fmt.Sprintf("Take another look at #%s.", reminder.payload.ChannelName),
 		Color:       0xFEE75C,
 		Timestamp:   time.Now().Format(time.RFC3339),
 	}
 
 	if reminder.payload.ContentSnippet != "" {
 		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
-			Name:  "メモ",
+			Name:  "📝 Note",
 			Value: reminder.payload.ContentSnippet,
 		})
 	}
 
 	if reminder.payload.JumpURL != "" {
 		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
-			Name:  "元メッセージ",
-			Value: fmt.Sprintf("[リンクはこちら](%s)", reminder.payload.JumpURL),
+			Name:  "🔗 Source Message",
+			Value: fmt.Sprintf("[Open message](%s)", reminder.payload.JumpURL),
 		})
 	}
 
 	if reminder.payload.BookmarkURL != "" {
 		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
-			Name:  "ブックマーク",
-			Value: fmt.Sprintf("[DMを開く](%s)", reminder.payload.BookmarkURL),
+			Name:  "📬 Saved Bookmark",
+			Value: fmt.Sprintf("[Open DM](%s)", reminder.payload.BookmarkURL),
 		})
 	}
 


### PR DESCRIPTION
## Summary
- add a `/remove-bookmark` command and wire it into the bot lifecycle
- translate all user-facing copy to clear English with emoji guidance and reminder text updates
- refresh the README with a capabilities overview and mention of the new command

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dd09dad2d0833088b47267ca4082af